### PR TITLE
feat: Add Platforms Page with Game Filtering by Selected Platform

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Home from './pages/Home';
 import SearchResults from './pages/SearchResults';
 import UpcomingGames from './pages/UpcomingGames';
 import Genres from './pages/Genres';
+import PlatformsPage from './pages/Platforms';
 
 
 
@@ -17,6 +18,7 @@ const App: React.FC = () => {
         <Route path="/search" element={<SearchResults />} />
         <Route path="/upcoming" element={<UpcomingGames />} />
         <Route path="/genres" element={<Genres />} />
+        <Route path="platforms" element={<PlatformsPage />} />
         {/* Add routes for other pages */}
       </Routes>
     </Router>

--- a/src/components/SpinningLoader.tsx
+++ b/src/components/SpinningLoader.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 const SpinningLoader: React.FC<{ message?: string }> = ({ message = "Please Wait Content Loading" }) => {
     return (
-        <div className="d-flex justify-content-center align-items-center" style={{ height: '60vh' }}>
+        <div className="d-flex flex-column align-items-center justify-content-center align-items-center" style={{ height: '60vh' }}>
             <h1> {message}</h1>
             <div className="spinner-border text-primary">
                 <span className="visually-hidden">Loading...</span>

--- a/src/pages/Platforms.tsx
+++ b/src/pages/Platforms.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { fetchPlatforms, fetchGamesByPlatform } from '../services/api';
+import { IPlatform } from '../types/platform';
+import { IGame } from '../types/game';
+import GameCard from '../components/GameCard';
+import SpinningLoader from '../components/SpinningLoader';
+
+const PlatformsPage: React.FC = () => {
+    const [platforms, setPlatforms] = useState<IPlatform[]>([]);
+    const [selectedPlatform, setSelectedPlatform] = useState<IPlatform | null>(null);
+    const [games, setGames] = useState<IGame[]>([]);
+    const [loadingPlatforms, setLoadingPlatforms] = useState(true);
+    const [loadingGames, setLoadingGames] = useState(false);
+
+    useEffect(() => {
+        fetchPlatforms()
+            .then(setPlatforms)
+            .finally(() => setLoadingPlatforms(false));
+    }, []);
+
+    useEffect(() => {
+        if (!selectedPlatform) return;
+        setLoadingGames(true);
+        fetchGamesByPlatform(selectedPlatform.id)
+            .then(setGames)
+            .finally(() => setLoadingGames(false));
+    }, [selectedPlatform]);
+
+    if (loadingPlatforms) return <SpinningLoader message='Please Wait Platforms are Loading..' />;
+
+    return (
+        <div className="container mt-4">
+            <h1 className="mb-4 text-center">Browse by Platform</h1>
+            <div className="d-flex flex-wrap gap-2 justify-content-center mb-4">
+                {platforms.map((platform) => (
+                    <button
+                        key={platform.id}
+                        className={`btn ${selectedPlatform?.id === platform.id ? 'btn-primary' : 'btn-outline-primary'}`}
+                        onClick={() => setSelectedPlatform(platform)}
+                    >
+                        {platform.name}
+                    </button>
+                ))}
+            </div>
+
+            {!selectedPlatform && <h1 className='text-center fw-semibold text-warning'> Please Choose any Patforms to Load The Games!</h1>}
+            {loadingGames && <SpinningLoader />}
+            {!loadingGames && selectedPlatform && (
+                <>
+                    <h2 className="text-center mb-3">
+                        Showing games on "{selectedPlatform.name}"
+                    </h2>
+                    <div className="d-flex flex-wrap gap-1 justify-content-center mt-4">
+                        {games.length > 0 ? (
+                            games.map((game) => <GameCard key={game.id} game={game} />)
+                        ) : (
+                            <p>No games available for this platform.</p>
+                        )}
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+export default PlatformsPage;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,6 @@
 import { IGame } from "../types/game";
 import { IGenre } from "../types/genre";
+import { IPlatform } from "../types/platform";
 
 const API_KEY = import.meta.env.VITE_RAWG_API_KEY;
 const BASE_URL = 'https://api.rawg.io/api';
@@ -26,6 +27,18 @@ export const fetchGenres = async (): Promise<IGenre[]> => {
 
 export const fetchGamesByGenre = async (genreId: number): Promise<IGame[]> => {
   const res = await fetch(`${BASE_URL}/games?genres=${genreId}&key=${API_KEY}`);
+  const data = await res.json();
+  return data.results;
+};
+
+export const fetchPlatforms = async (): Promise<IPlatform[]> => {
+  const res = await fetch(`${BASE_URL}/platforms?key=${API_KEY}`);
+  const data = await res.json();
+  return data.results;
+};
+
+export const fetchGamesByPlatform = async (platformId: number): Promise<IGame[]> => {
+  const res = await fetch(`${BASE_URL}/games?platforms=${platformId}&key=${API_KEY}`);
   const data = await res.json();
   return data.results;
 };

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -1,0 +1,6 @@
+export interface IPlatform {
+    id: number;
+    name: string;
+    slug: string;
+  }
+  


### PR DESCRIPTION
## 🚀 Platforms Page

### 📝 Description:
This PR introduces a new **"Platforms"** page that enables users to browse games based on their selected gaming platform.

### ✨ Features:
- **Platform Fetching:** Dynamically retrieves a list of platforms from the RAWG API.
- **Game Filtering:** Displays games specific to the platform selected by the user.
- **Loading Indicators:** Includes spinners for both platform and game data fetch processes to improve UX.
- **Responsive UI:** Ensures a seamless experience across different device sizes.
- **Dynamic UI Update:** Highlights the selected platform and fetches associated games in real-time.

### 🧪 Testing Instructions:
- Navigate to the **"Platforms"** page from the navbar.
- Observe the loading spinner while platforms are being fetched.
- Click on a platform button.
- Ensure relevant games are displayed and a loader shows up during the fetch.
- Verify responsiveness by resizing the window or viewing on different devices.

### 📌 Additional Notes:
- Buttons for platforms are generated dynamically based on the API response.
- The feature can be further enhanced with pagination or infinite scrolling in the future.

--- 
