### PR TITLE
Fix platforms typo

### DIFF
--- a/src/pages/Platforms.tsx
+++ b/src/pages/Platforms.tsx
@@ -43,7 +43,7 @@ const PlatformsPage: React.FC = () => {
                 ))}
             </div>
 
-            {!selectedPlatform && <h1 className='text-center fw-semibold text-warning'> Please Choose any Patforms to Load The Games!</h1>}
+            {!selectedPlatform && <h1 className='text-center fw-semibold text-warning'> Please Choose any Platforms to Load The Games!</h1>}
             {loadingGames && <SpinningLoader />}
             {!loadingGames && selectedPlatform && (
                 <>


### PR DESCRIPTION
## Summary
- fix typo in Platforms page empty-state header

## Testing
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6841322543f08324a8f87e2f824be330