### PR TITLE
Add Vitest setup and test for ThemeToggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "6.2.7",
+    "vite": "^6.2.7",
     "vitest": "^1.4.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0",
+    "vite": "^7.0.0",
     "vitest": "^1.4.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
@@ -31,6 +32,11 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jsdom": "^24.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "globals": "^15.15.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
-    "vite": "^7.0.0",
+    "vite": "6.2.7",
     "vitest": "^1.4.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^6.4.0",

--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,26 @@
+/// <reference types="vitest" />
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ThemeToggle from '../ThemeToggle';
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.body.className = '';
+  });
+
+  it('toggling checkbox updates body class and localStorage', async () => {
+    render(<ThemeToggle />);
+    const checkbox = screen.getByRole('checkbox');
+
+    // initial state should be dark mode
+    expect(checkbox).toBeChecked();
+    expect(document.body.classList.contains('dark-mode')).toBe(true);
+    expect(localStorage.getItem('theme')).toBe('dark');
+
+    await userEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+    expect(document.body.classList.contains('dark-mode')).toBe(false);
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,12 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+  },
 })


### PR DESCRIPTION
## Summary
- set up Vitest with Testing Library for React
- add test script and dev dependencies
- add test file for `ThemeToggle`
- include Jest DOM setup

## Testing
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6841344e265c8324b63ad00f48c2a352