### PR TITLE
Add tests for components, API and search page

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ Get a free key from [RAWG.io](https://rawg.io/apidocs).
 yarn dev
 ```
 
+### 5. Run tests
+
+```bash
+yarn install
+yarn test
+```
+
 ---
 
 ## 📁 Folder Structure

--- a/src/components/__tests__/GameCard.test.tsx
+++ b/src/components/__tests__/GameCard.test.tsx
@@ -1,0 +1,49 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference types="vitest" />
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GameCard from '../GameCard';
+import { IGame } from '../../types/game';
+
+describe('GameCard & GameDetailsModal', () => {
+  const game: IGame = {
+    id: 1,
+    slug: 'sample',
+    name: 'Sample Game',
+    released: '2024-01-01',
+    tba: false,
+    background_image: '/sample.jpg',
+    rating: 4.5,
+    rating_top: 5,
+    ratings: [],
+    ratings_count: 0,
+    reviews_text_count: 0,
+    added: 0,
+    added_by_status: { yet: 0, owned: 0, beaten: 0, toplay: 0, dropped: 0, playing: 0 },
+    metacritic: 0,
+    playtime: 0,
+    suggestions_count: 0,
+    updated: '',
+    user_game: null,
+    reviews_count: 0,
+    saturated_color: '',
+    dominant_color: '',
+    platforms: [],
+    parent_platforms: [],
+    genres: [],
+    stores: [],
+  };
+
+  it('opens and closes details modal', async () => {
+    render(<GameCard game={game} />);
+    const detailsButton = screen.getByRole('button', { name: /details/i });
+    await userEvent.click(detailsButton);
+
+    const closeButton = screen.getByRole('button', { name: /×/i });
+    expect(closeButton).toBeInTheDocument();
+
+    await userEvent.click(closeButton);
+
+    expect(screen.queryByRole('button', { name: /×/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/SearchResults.test.tsx
+++ b/src/pages/__tests__/SearchResults.test.tsx
@@ -1,0 +1,72 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference types="vitest" />
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import SearchResults from '../SearchResults';
+import { vi } from 'vitest';
+import { IGame } from '../../types/game';
+
+vi.mock('axios');
+const mockedGet = vi.mocked(axios.get);
+
+const API_KEY = 'test-key';
+
+const game: IGame = {
+  id: 1,
+  slug: 'sample',
+  name: 'Sample Game',
+  released: '2024-01-01',
+  tba: false,
+  background_image: '/sample.jpg',
+  rating: 4.5,
+  rating_top: 5,
+  ratings: [],
+  ratings_count: 0,
+  reviews_text_count: 0,
+  added: 0,
+  added_by_status: { yet: 0, owned: 0, beaten: 0, toplay: 0, dropped: 0, playing: 0 },
+  metacritic: 0,
+  playtime: 0,
+  suggestions_count: 0,
+  updated: '',
+  user_game: null,
+  reviews_count: 0,
+  saturated_color: '',
+  dominant_color: '',
+  platforms: [],
+  parent_platforms: [],
+  genres: [],
+  stores: [],
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={[`/search?q=test`]}>
+      <SearchResults />
+    </MemoryRouter>
+  );
+
+describe('SearchResults', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_RAWG_API_KEY', API_KEY);
+    mockedGet.mockResolvedValue({ data: { results: [game] } });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetAllMocks();
+  });
+
+  it('renders game cards after fetch', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(game.name)).toBeInTheDocument();
+    });
+
+    expect(mockedGet).toHaveBeenCalledWith(
+      `https://api.rawg.io/api/games?search=test&key=${API_KEY}`
+    );
+  });
+});

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -1,0 +1,82 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference types="vitest" />
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const API_KEY = 'test-key';
+const BASE_URL = 'https://api.rawg.io/api';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+const loadApi = async () => {
+  vi.stubEnv('VITE_RAWG_API_KEY', API_KEY);
+  vi.resetModules();
+  const module = await import('../api');
+  return module;
+};
+
+beforeEach(() => {
+  fetchMock = vi.fn().mockResolvedValue({ json: vi.fn().mockResolvedValue(sampleResponse) });
+  global.fetch = fetchMock as any;
+});
+
+afterEach(() => {
+  vi.resetAllMocks();
+  vi.unstubAllEnvs();
+});
+
+const sampleResponse = { results: [{ id: 1 }] };
+
+describe('api services', () => {
+  it('fetchGames calls correct endpoint', async () => {
+    const { fetchGames } = await loadApi();
+    const data = await fetchGames();
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/games?key=${API_KEY}`);
+    expect(data).toEqual(sampleResponse.results);
+  });
+
+  it('fetchUpcomingGames builds dates url', async () => {
+    const { fetchUpcomingGames } = await loadApi();
+    await fetchUpcomingGames();
+    const today = new Date().toISOString().split('T')[0];
+    const nextYearEnd = new Date(new Date().getFullYear() + 1, 11, 31).toISOString().split('T')[0];
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/games?dates=${today},${nextYearEnd}&ordering=-added&page_size=20&key=${API_KEY}`
+    );
+  });
+
+  it('fetchGenres calls genres endpoint', async () => {
+    const { fetchGenres } = await loadApi();
+    await fetchGenres();
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/genres?key=${API_KEY}`);
+  });
+
+  it('fetchGamesByGenre uses provided id', async () => {
+    const { fetchGamesByGenre } = await loadApi();
+    await fetchGamesByGenre(3);
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/games?genres=3&key=${API_KEY}`);
+  });
+
+  it('fetchPlatforms calls platforms endpoint', async () => {
+    const { fetchPlatforms } = await loadApi();
+    await fetchPlatforms();
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/platforms?key=${API_KEY}`);
+  });
+
+  it('fetchGamesByPlatform uses provided id', async () => {
+    const { fetchGamesByPlatform } = await loadApi();
+    await fetchGamesByPlatform(5);
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/games?platforms=5&key=${API_KEY}`);
+  });
+
+  it('fetchTopRatedGames orders by rating', async () => {
+    const { fetchTopRatedGames } = await loadApi();
+    await fetchTopRatedGames();
+    expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/games?ordering=-rating&page_size=20&key=${API_KEY}`);
+  });
+
+  it('propagates fetch errors', async () => {
+    fetchMock.mockRejectedValue(new Error('fail'));
+    const { fetchGames } = await loadApi();
+    await expect(fetchGames()).rejects.toThrow('fail');
+  });
+});


### PR DESCRIPTION
## Summary
- add GameCard modal behavior test
- mock fetch for API service tests
- test SearchResults page with mocked Axios
- document how to run tests in README

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68426edfb474832482ce8b2207f8013d