### PR TITLE
Fix vitest imports in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/bootstrap": "^5.2.10",
+    "@types/node": "^22.15.30",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "@vitejs/plugin-react": "^4.3.4",
@@ -30,13 +34,10 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^15.15.0",
+    "jsdom": "^24.0.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.7",
-    "vitest": "^1.4.0",
-    "@testing-library/react": "^14.0.0",
-    "@testing-library/jest-dom": "^6.4.0",
-    "@testing-library/user-event": "^14.4.3",
-    "jsdom": "^24.0.0"
+    "vitest": "^1.4.0"
   }
 }

--- a/src/components/__tests__/GameCard.test.tsx
+++ b/src/components/__tests__/GameCard.test.tsx
@@ -1,0 +1,44 @@
+/// <reference types="vitest" />
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+import GameCard from '../GameCard';
+import { IGame } from '../../types/game';
+
+const mockGame: IGame = {
+  id: 1,
+  slug: 'game-1',
+  name: 'Game 1',
+  released: '2020-01-01',
+  tba: false,
+  background_image: '/assets/svg/no-game-image.svg',
+  rating: 4,
+  rating_top: 5,
+  ratings: [],
+  ratings_count: 0,
+  reviews_text_count: 0,
+  added: 0,
+  added_by_status: { yet: 0, owned: 0, beaten: 0, toplay: 0, dropped: 0, playing: 0 },
+  metacritic: 0,
+  playtime: 0,
+  suggestions_count: 0,
+  updated: '',
+  user_game: null,
+  reviews_count: 0,
+  saturated_color: '',
+  dominant_color: '',
+  platforms: [],
+  parent_platforms: [],
+  genres: [],
+  stores: [],
+};
+
+describe('GameCard', () => {
+  it('opens modal when Details button is clicked', async () => {
+    render(<GameCard game={mockGame} />);
+    const btn = screen.getByRole('button', { name: /details/i });
+    await userEvent.click(btn);
+    // Modal should appear
+    expect(screen.getByRole('button', { name: /×/i })).toBeInTheDocument();
+  });
+});

--- a/src/pages/__tests__/SearchResults.test.tsx
+++ b/src/pages/__tests__/SearchResults.test.tsx
@@ -1,0 +1,30 @@
+/// <reference types="vitest" />
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import axios from 'axios';
+import SearchResults from '../SearchResults';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('axios');
+
+describe('SearchResults', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (axios.get as unknown as any).mockResolvedValue({ data: { results: [] } });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches games on mount', async () => {
+    render(
+      <MemoryRouter initialEntries={["/search?q=test"]}>
+        <SearchResults />
+      </MemoryRouter>
+    );
+    const heading = await screen.findByText(/Search Results/i);
+    expect(heading).toBeInTheDocument();
+    expect(axios.get).toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -1,5 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference types="vitest" />
+/// <reference types="node" />
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const API_KEY = 'test-key';

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -18,7 +18,7 @@ const loadApi = async () => {
 
 beforeEach(() => {
   fetchMock = vi.fn().mockResolvedValue({ json: vi.fn().mockResolvedValue(sampleResponse) });
-  global.fetch = fetchMock as any;
+  (global as any).fetch = fetchMock;
 });
 
 afterEach(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,17 @@
 {
   "files": [],
   "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    {
+      "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "build",
+    "**/*.test.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,7 @@
 {
   "files": [],
   "references": [
-    {
-      "path": "./tsconfig.app.json"
-    },
-    {
-      "path": "./tsconfig.node.json"
-    }
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "build",
-    "**/*.test.ts"
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,6 +988,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/node@^22.15.30":
+  version "22.15.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.30.tgz#3a20431783e28dd0b0326f84ab386a2ec81d921d"
+  integrity sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==
+  dependencies:
+    undici-types "~6.21.0"
+
 "@types/prop-types@^15.7.12":
   version "15.7.14"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.14.tgz#1433419d73b2a7ebfc6918dcefd2ec0d5cd698f2"
@@ -3224,6 +3231,11 @@ uncontrollable@^8.0.4:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-8.0.4.tgz#a0a8307f638795162fafd0550f4a1efa0f8c5eb6"
   integrity sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 universalify@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
## Summary
- add missing vitest imports for GameCard and SearchResults tests
- implement basic tests for GameCard and SearchResults

## Testing
- `npx vitest run`
- `npx tsc -p tsconfig.app.json`


------
https://chatgpt.com/codex/tasks/task_e_68427890e9f88324b8ea77e3be3282b1