### PR TITLE
Handle API errors and display alerts

### DIFF
--- a/src/pages/Genres.tsx
+++ b/src/pages/Genres.tsx
@@ -11,20 +11,31 @@ const GenresPage: React.FC = () => {
     const [games, setGames] = useState<IGame[]>([]);
     const [gamesLoading, setGamesLoading] = useState(true);
     const [genreLoading, setGenreLoading] = useState(true);
+    const [genreError, setGenreError] = useState<string | null>(null);
+    const [gamesError, setGamesError] = useState<string | null>(null);
 
     useEffect(() => {
         setGenreLoading(true);
+        setGenreError(null);
         fetchGenres()
             .then(setGenres)
-            .catch(err => console.error(err))
+            .catch(err => {
+                console.error(err);
+                setGenreError('Failed to fetch genres.');
+            })
             .finally(() => setGenreLoading(false));
     }, []);
 
     useEffect(() => {
         if (!selectedGenre) return;
         setGamesLoading(true);
+        setGamesError(null);
         fetchGamesByGenre(selectedGenre.id)
             .then((data) => setGames(data))
+            .catch(err => {
+                console.error(err);
+                setGamesError('Failed to fetch games.');
+            })
             .finally(() => setGamesLoading(false));
     }, [selectedGenre]);
 
@@ -34,6 +45,7 @@ const GenresPage: React.FC = () => {
     return (
         <div className="container mt-4">
             <h1 className="mb-4 text-center">Browse by Genre</h1>
+            {genreError && <div className="alert alert-danger">{genreError}</div>}
             <div className="d-flex flex-wrap gap-2 justify-content-center mb-4">
                 {genres.map((g) => (
                     <button
@@ -48,6 +60,7 @@ const GenresPage: React.FC = () => {
             </div>
 
             {selectedGenre && gamesLoading && <SpinningLoader />}
+            {gamesError && <div className="alert alert-danger">{gamesError}</div>}
             {!selectedGenre && (<p className="text-center"> Please select a genre above to see its games. </p>)}
             {!gamesLoading && selectedGenre && (
                 <div className="container-fluid mt-4">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,14 +9,21 @@ const Home: React.FC = () => {
   const [games, setGames] = useState<IGame[]>([]);
   const [topGames, setTopGames] = useState<IGame[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchGames().then((data) => {
-      setGames(data);
-      const sortedGamesByRatings = [...data].sort((a, b) => b.rating - a.rating);
-      setTopGames(sortedGamesByRatings.slice(0, 3));
-      setLoading(false);
-    });
+    setLoading(true);
+    fetchGames()
+      .then((data) => {
+        setGames(data);
+        const sortedGamesByRatings = [...data].sort((a, b) => b.rating - a.rating);
+        setTopGames(sortedGamesByRatings.slice(0, 3));
+      })
+      .catch((err) => {
+        console.error(err);
+        setError('Failed to fetch games.');
+      })
+      .finally(() => setLoading(false));
   }, []);
 
   if (loading) {
@@ -26,6 +33,7 @@ const Home: React.FC = () => {
     <div className="container-fluid mt-4">
       <TopGamesCarousel topGames={topGames} />
       <h1 className="mb-4 text-center">Game Details</h1>
+      {error && <div className="alert alert-danger">{error}</div>}
       <div className="game-grid d-flex flex-wrap gap-4 justify-content-center">
         {games.map((game) => (
           <GameCard key={game.id} game={game} />

--- a/src/pages/Platforms.tsx
+++ b/src/pages/Platforms.tsx
@@ -11,18 +11,29 @@ const PlatformsPage: React.FC = () => {
     const [games, setGames] = useState<IGame[]>([]);
     const [loadingPlatforms, setLoadingPlatforms] = useState(true);
     const [loadingGames, setLoadingGames] = useState(false);
+    const [platformError, setPlatformError] = useState<string | null>(null);
+    const [gamesError, setGamesError] = useState<string | null>(null);
 
     useEffect(() => {
         fetchPlatforms()
             .then(setPlatforms)
+            .catch(err => {
+                console.error(err);
+                setPlatformError('Failed to fetch platforms.');
+            })
             .finally(() => setLoadingPlatforms(false));
     }, []);
 
     useEffect(() => {
         if (!selectedPlatform) return;
         setLoadingGames(true);
+        setGamesError(null);
         fetchGamesByPlatform(selectedPlatform.id)
             .then(setGames)
+            .catch(err => {
+                console.error(err);
+                setGamesError('Failed to fetch games.');
+            })
             .finally(() => setLoadingGames(false));
     }, [selectedPlatform]);
 
@@ -31,6 +42,7 @@ const PlatformsPage: React.FC = () => {
     return (
         <div className="container mt-4">
             <h1 className="mb-4 text-center">Browse by Platform</h1>
+            {platformError && <div className="alert alert-danger">{platformError}</div>}
             <div className="d-flex flex-wrap gap-2 justify-content-center mb-4">
                 {platforms.map((platform) => (
                     <button
@@ -45,6 +57,7 @@ const PlatformsPage: React.FC = () => {
 
             {!selectedPlatform && <h1 className='text-center fw-semibold text-warning'> Please Choose any Platforms to Load The Games!</h1>}
             {loadingGames && <SpinningLoader />}
+            {gamesError && <div className="alert alert-danger">{gamesError}</div>}
             {!loadingGames && selectedPlatform && (
                 <>
                     <h2 className="text-center mb-3">

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -11,18 +11,21 @@ const SearchResults: React.FC = () => {
     const query = new URLSearchParams(location.search).get('q') || '';
     const [games, setGames] = useState<IGame[]>([]);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
 
 
     useEffect(() => {
         const fetchGames = async () => {
             try {
                 setLoading(true);
+                setError(null);
                 const res = await axios.get(
                     `https://api.rawg.io/api/games?search=${query}&key=${import.meta.env.VITE_RAWG_API_KEY}`
                 );
                 setGames(res.data.results);
             } catch (err) {
                 console.error('Search fetch error:', err);
+                setError('Failed to fetch search results.');
             } finally {
                 setLoading(false);
             }
@@ -34,6 +37,7 @@ const SearchResults: React.FC = () => {
     return (
         <div className="container mt-4">
             <h2>Search Results for: <em>{query}</em></h2>
+            {error && <div className="alert alert-danger">{error}</div>}
             {loading ? (
                 <SpinningLoader />
             ) : games.length === 0 ? (

--- a/src/pages/TopRatedGames.tsx
+++ b/src/pages/TopRatedGames.tsx
@@ -8,16 +8,22 @@ const TopRatedGames: React.FC = () => {
 
     const [games, setGames] = useState<IGame[]>([]);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
         fetchTopRatedGames()
             .then(setGames)
+            .catch(err => {
+                console.error(err);
+                setError('Failed to fetch games.');
+            })
             .finally(() => setLoading(false));
     }, []);
 
     return (
         <div className="container-fluid mt-4">
             <h1 className="mb-4 text-center">Top Rated Games</h1>
+            {error && <div className="alert alert-danger">{error}</div>}
             {
                 loading ? (<SpinningLoader />)
                     :

--- a/src/pages/UpcomingGames.tsx
+++ b/src/pages/UpcomingGames.tsx
@@ -7,10 +7,15 @@ import SpinningLoader from '../components/SpinningLoader';
 const UpcomingGames: React.FC = () => {
     const [games, setGames] = useState<IGame[]>([]);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
 
     useEffect(() => {
         fetchUpcomingGames()
             .then(setGames)
+            .catch(err => {
+                console.error(err);
+                setError('Failed to fetch games.');
+            })
             .finally(() => setLoading(false));
     }, []);
 
@@ -21,6 +26,7 @@ const UpcomingGames: React.FC = () => {
     return (
         <div className="container-fluid mt-4">
             <h1 className="mb-4 text-center">Upcoming Games</h1>
+            {error && <div className="alert alert-danger">{error}</div>}
             <div className="game-grid d-flex flex-wrap gap-4 justify-content-center">
                 {games.map((game) => (
                     <GameCard key={game.id} game={game} />

--- a/src/pages/__tests__/SearchResults.test.tsx
+++ b/src/pages/__tests__/SearchResults.test.tsx
@@ -11,6 +11,7 @@ vi.mock('axios');
 describe('SearchResults', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (axios.get as unknown as any).mockResolvedValue({ data: { results: [] } });
   });
 
@@ -27,5 +28,19 @@ describe('SearchResults', () => {
     const heading = await screen.findByText(/Search Results/i);
     expect(heading).toBeInTheDocument();
     expect(axios.get).toHaveBeenCalled();
+  });
+
+  it('displays error when fetch fails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (axios.get as unknown as any).mockRejectedValue(new Error('fail'));
+
+    render(
+      <MemoryRouter initialEntries={["/search?q=test"]}>
+        <SearchResults />
+      </MemoryRouter>
+    );
+
+    const alert = await screen.findByText(/failed to fetch search results/i);
+    expect(alert).toBeInTheDocument();
   });
 });

--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -18,6 +18,7 @@ const loadApi = async () => {
 
 beforeEach(() => {
   fetchMock = vi.fn().mockResolvedValue({ json: vi.fn().mockResolvedValue(sampleResponse) });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (global as any).fetch = fetchMock;
 });
 


### PR DESCRIPTION
## Summary
- track fetch errors across pages and show Bootstrap alerts when requests fail
- add error handling to SearchResults and create accompanying tests
- adjust other pages (Home, Genres, Platforms, TopRatedGames, UpcomingGames) to store and display error state
- silence lint on test mocks

## Testing
- `yarn lint`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_684286b4635c8324af31bf1d3e08b2a1