### PR TITLE
Move game-grid styles to global CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -31,3 +31,10 @@ body.dark-mode {
   box-sizing: border-box;
   transition: all 0.3s ease-in-out;
 }
+
+/* Shared grid layout for game cards */
+.game-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.5rem;
+}

--- a/src/pages/styles/SearchResults.css
+++ b/src/pages/styles/SearchResults.css
@@ -10,11 +10,6 @@
     color: #222;
 }
 
-.game-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 1.5rem;
-}
 
 /* Loading and empty state */
 .search-results-container p {


### PR DESCRIPTION
## Summary
- centralize `.game-grid` layout rules in `index.css`
- remove duplicate grid rules from `SearchResults.css`

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684286bf7f208324befdda5e7202095a