### PR TITLE
Add lazy loading and alt fallback

### DIFF
--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -12,7 +12,8 @@ const GameCard: React.FC<{ game: IGame }> = ({ game }) => {
                 <img
                     src={game.background_image || '/assets/svg/no-game-image.svg'}
                     className="card-img-top"
-                    alt={game.name}
+                    alt={game.background_image ? game.name : `No image available for ${game.name}`}
+                    loading="lazy"
                 />
 
                 <div className="card-body">

--- a/src/components/__tests__/GameCard.test.tsx
+++ b/src/components/__tests__/GameCard.test.tsx
@@ -42,4 +42,11 @@ describe('GameCard', () => {
     // Modal should appear
     expect(screen.getByRole('button', { name: /×/i })).toBeInTheDocument();
   });
+
+  it('uses placeholder alt text when image is missing', () => {
+    const gameWithoutImage = { ...mockGame, background_image: '' };
+    render(<GameCard game={gameWithoutImage} />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', 'No image available for Game 1');
+  });
 });


### PR DESCRIPTION
## Summary
- use lazy loading on game card images
- add meaningful alt text when a game's image is missing
- test alt text logic

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684286ceb1e88324bbe3290b6a53d4db