### PR TITLE
Add star rating display to GameCard

### DIFF
--- a/src/components/GameCard.tsx
+++ b/src/components/GameCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { IGame } from '../types/game';
 import './styles/GameCard.css';
 import GameDetailsModal from './GameDetailsModal';
+import { FaStar } from 'react-icons/fa';
 
 const GameCard: React.FC<{ game: IGame }> = ({ game }) => {
     const [isModalOpen, setIsModalOpen] = useState(false);
@@ -19,7 +20,11 @@ const GameCard: React.FC<{ game: IGame }> = ({ game }) => {
                 <div className="card-body">
                     <h5 className="card-title fw-semibold">{game.name}</h5>
                     <p className="card-text mb-1"><strong>Released:</strong> {game.released}</p>
-                    <p className="card-text"><strong>Rating:</strong> {game.rating}</p>
+                    <div className="rating-stars">
+                        {Array.from({ length: Math.round(game.rating) }, (_, i) => (
+                            <FaStar data-testid="star-icon" key={i} className="rating-star" />
+                        ))}
+                    </div>
                     <button className="btn btn-primary" onClick={() => setIsModalOpen(true)}>Details</button>
                 </div>
             </div>

--- a/src/components/__tests__/GameCard.test.tsx
+++ b/src/components/__tests__/GameCard.test.tsx
@@ -49,4 +49,10 @@ describe('GameCard', () => {
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('alt', 'No image available for Game 1');
   });
+
+  it('renders correct number of star icons', () => {
+    render(<GameCard game={mockGame} />);
+    const stars = screen.getAllByTestId('star-icon');
+    expect(stars).toHaveLength(mockGame.rating);
+  });
 });

--- a/src/components/styles/GameCard.css
+++ b/src/components/styles/GameCard.css
@@ -79,3 +79,14 @@ body.dark-mode .game-card .btn-primary {
 .game-card .btn:hover {
     opacity: 0.8;
 }
+
+/* Rating stars */
+.rating-stars {
+    display: flex;
+    margin-bottom: 8px;
+}
+
+.rating-star {
+    color: #ffbf00;
+    margin-right: 4px;
+}


### PR DESCRIPTION
## Summary
- show star icons on game cards via `react-icons`
- style new rating star container
- verify stars render in GameCard tests

## Testing
- `yarn lint`
- `yarn test --run`

------
https://chatgpt.com/codex/tasks/task_e_68428c04849883249a662149a1cf016d