### PR TITLE
Add dark-mode CSS variable overrides

### DIFF
--- a/src/components/styles/GameCard.css
+++ b/src/components/styles/GameCard.css
@@ -2,8 +2,8 @@
 
 /* Game Card Styles */
 .game-card {
-    background-color: #ffffff;
-    color: #333;
+    background-color: var(--surface-bg);
+    color: var(--text-color-light);
     border-radius: 16px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     overflow: hidden;
@@ -15,7 +15,7 @@
     width: 100%;
     height: 200px;
     object-fit: cover;
-    background-color: #ffffff;
+    background-color: var(--surface-bg);
 }
 
 .game-card .card-body {
@@ -29,33 +29,33 @@
 
 /* Dark Mode Game Card */
 body.dark-mode .game-card {
-    background-color: #2a2a2a;
-    color: #f0f0f0;
+    background-color: var(--surface-bg);
+    color: var(--text-color-dark);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
 body.dark-mode .game-card .card-body {
-    background-color: #333;
+    background-color: var(--surface-alt-bg);
 }
 
 /* Game Card Text */
 .game-card .card-title {
     font-size: 1.25rem;
     font-weight: 600;
-    color: #333;
+    color: var(--text-color-light);
 }
 
 body.dark-mode .game-card .card-title {
-    color: #e0e0e0;
+    color: var(--text-color-dark);
 }
 
 .game-card .card-text {
     font-size: 0.9rem;
-    color: #555;
+    color: var(--text-color-light);
 }
 
 body.dark-mode .game-card .card-text {
-    color: #bbb;
+    color: var(--text-color-dark);
 }
 
 /* Button Style */
@@ -72,9 +72,6 @@ body.dark-mode .game-card .card-text {
     border: none;
 }
 
-body.dark-mode .game-card .btn-primary {
-    background-color: #ffbf00;
-}
 
 .game-card .btn:hover {
     opacity: 0.8;

--- a/src/components/styles/GameDetailsModal.css
+++ b/src/components/styles/GameDetailsModal.css
@@ -72,7 +72,7 @@
     gap: 1rem;
     font-size: 1rem;
     line-height: 1.6;
-    color: #333;
+    color: var(--text-color-light);
 }
 
 .modal-image {
@@ -109,7 +109,7 @@ body.dark-mode .modal-box::-webkit-scrollbar-thumb {
 }
 
 body.dark-mode .modal-box::-webkit-scrollbar-track {
-    background-color: #333;
+    background-color: var(--surface-alt-bg);
 }
 
 body.dark-mode .close-button {

--- a/src/components/styles/GameDetailsModal.css
+++ b/src/components/styles/GameDetailsModal.css
@@ -10,7 +10,7 @@
 }
 
 .modal-box {
-    background-color: #fff;
+    background-color: var(--surface-bg);
     border-radius: 20px;
     width: 90%;
     max-width: 900px;
@@ -43,7 +43,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid var(--border-color);
     padding-bottom: 10px;
     margin-bottom: 15px;
 }
@@ -96,12 +96,12 @@
 
 /* Dark Mode Support */
 body.dark-mode .modal-box {
-    background-color: #222;
-    color: #e0e0e0;
+    background-color: var(--surface-bg);
+    color: var(--text-color-dark);
 }
 
 body.dark-mode .modal-header {
-    border-bottom: 1px solid #444;
+    border-bottom: 1px solid var(--border-color);
 }
 
 body.dark-mode .modal-box::-webkit-scrollbar-thumb {
@@ -113,8 +113,8 @@ body.dark-mode .modal-box::-webkit-scrollbar-track {
 }
 
 body.dark-mode .close-button {
-    color: #e0e0e0;
+    color: var(--text-color-dark);
 }
 body.dark-mode .modal-body {
-    color: #e0e0e0;
+    color: var(--text-color-dark);
 }

--- a/src/components/styles/NavBar.css
+++ b/src/components/styles/NavBar.css
@@ -2,15 +2,12 @@
 
 /* Navbar Styles */
 .navbar {
-    background-color: #fff;
+    background-color: var(--navbar-bg, var(--surface-bg));
     padding: 1rem 2rem;
-    border-bottom: 2px solid #ddd;
+    border-bottom: 2px solid var(--border-color);
     transition: background-color 0.3s ease, color 0.3s ease;
 }
 
-body.dark-mode .navbar {
-    background-color: #2a2a2a;
-}
 
 .navbar .container {
     display: flex;
@@ -26,7 +23,7 @@ body.dark-mode .navbar {
 }
 
 body.dark-mode .navbar-brand {
-    color: #ffbf00;
+    color: var(--primary-color);
 }
 
 body.dark-mode .navbar-brand:hover {
@@ -56,17 +53,17 @@ body.dark-mode .nav-link {
 }
 
 body.dark-mode .nav-link:hover {
-    color: #ffbf00;
+    color: var(--primary-color);
 }
 .navbar-search-form {
     display: flex;
     align-items: center;
     margin-left: 1rem;
-    background-color: #fff;
+    background-color: var(--search-bg);
     border-radius: 6px;
     overflow: hidden;
     height: 36px;
-    border: 1px solid #ccc;
+    border: 1px solid var(--search-border-color);
 }
 
 .navbar-search-input {
@@ -75,7 +72,7 @@ body.dark-mode .nav-link:hover {
     font-size: 0.9rem;
     outline: none;
     background-color: transparent;
-    color: #333;
+    color: var(--text-color-light);
 }
 
 .navbar-search-button {
@@ -85,18 +82,18 @@ body.dark-mode .nav-link:hover {
     cursor: pointer;
     display: flex;
     align-items: center;
-    color: #333;
+    color: var(--text-color-light);
 }
 
 body.dark-mode .navbar-search-form {
-    background-color: #444;
-    border: 1px solid #666;
+    background-color: var(--search-bg);
+    border: 1px solid var(--search-border-color);
 }
 
 body.dark-mode .navbar-search-input {
-    color: #f0f0f0;
+    color: var(--text-color-dark);
 }
 
 body.dark-mode .navbar-search-button {
-    color: #f0f0f0;
+    color: var(--text-color-dark);
 }

--- a/src/components/styles/ThemeToggle.css
+++ b/src/components/styles/ThemeToggle.css
@@ -18,15 +18,15 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: #007bff;
+  background-color: var(--primary-color);
     transition: 0.4s;
     border-radius: 34px;
   }
   
 
-  input:checked + .slider {
-    background-color: #ffbf00;
-  }
+input:checked + .slider {
+  background-color: var(--primary-color);
+}
   
   /* The circle inside the slider */
   .slider:before {

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,12 @@
   --light-bg-color: #f9f9f9;
   --text-color-light: #222;
   --text-color-dark: #eee;
+  --surface-bg: #fff;
+  --surface-alt-bg: #fff;
+  --border-color: #ddd;
+  --search-border-color: #ccc;
+  --search-bg: #fff;
+  --navbar-bg: #fff;
 }
 
 /* Global body styling */
@@ -24,6 +30,13 @@ body {
 body.dark-mode {
   background-color: var(--dark-bg-color);
   color: var(--text-color-dark);
+  --primary-color: #ffbf00;
+  --surface-bg: #2a2a2a;
+  --surface-alt-bg: #333;
+  --border-color: #666;
+  --search-border-color: #666;
+  --search-bg: #444;
+  --navbar-bg: #2a2a2a;
 }
 
 /* Smooth transitions for elements */

--- a/src/pages/styles/SearchResults.css
+++ b/src/pages/styles/SearchResults.css
@@ -7,22 +7,23 @@
 .search-results-container h2 {
     font-size: 1.75rem;
     margin-bottom: 1.5rem;
-    color: #222;
+    color: var(--text-color-light);
 }
 
 
 /* Loading and empty state */
 .search-results-container p {
     font-size: 1.1rem;
-    color: #666;
+    color: var(--text-color-light);
     text-align: center;
 }
 
 /* Dark mode */
 body.dark-mode .search-results-container h2 {
-    color: #f0f0f0;
+    color: var(--text-color-dark);
 }
 
 body.dark-mode .search-results-container p {
-    color: #bbb;
+    color: var(--text-color-dark);
 }
+


### PR DESCRIPTION
## Summary
- declare custom color variables and override them in `body.dark-mode`
- update component styles to rely on variables instead of hard-coded colors
- keep dark and light themes consistent

## Testing
- `yarn test`
- `yarn dev` *(stopped after launch)*

------
https://chatgpt.com/codex/tasks/task_e_68428bfea1108324bd32a4c96bc5cd05