### PR TITLE
Update spinner loader

### DIFF
--- a/src/components/SpinningLoader.tsx
+++ b/src/components/SpinningLoader.tsx
@@ -2,30 +2,9 @@ import React from "react";
 
 const SpinningLoader: React.FC<{ message?: string }> = ({ message = "Please Wait Content Loading" }) => {
     return (
-        <div className="d-flex flex-column align-items-center justify-content-center align-items-center" style={{ height: '60vh' }}>
-            <h1> {message}</h1>
-            <div className="spinner-border text-primary">
-                <span className="visually-hidden">Loading...</span>
-            </div>
-            <div className="spinner-border text-secondary">
-                <span className="visually-hidden">Loading...</span>
-            </div>
-            <div className="spinner-border text-success">
-                <span className="visually-hidden">Loading...</span>
-            </div>
-            <div className="spinner-border text-danger">
-                <span className="visually-hidden">Loading...</span>
-            </div>
-            <div className="spinner-border text-warning">
-                <span className="visually-hidden">Loading...</span>
-            </div>
-            <div className="spinner-border text-info">
-                <span className="visually-hidden">Loading...</span>
-            </div>
-            <div className="spinner-border text-light">
-                <span className="visually-hidden">Loading...</span>
-            </div>
-            <div className="spinner-border text-dark">
+        <div className="d-flex flex-column align-items-center justify-content-center" style={{ height: '60vh' }}>
+            <h1>{message}</h1>
+            <div className="spinner-border" role="status">
                 <span className="visually-hidden">Loading...</span>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- simplify loader markup to use a single spinner
- center the loader message and spinner

## Testing
- `yarn test --run`


------
https://chatgpt.com/codex/tasks/task_e_68428c094398832484716ddd55f64682