### PR TITLE
Implement close handlers for GameDetailsModal

### DIFF
--- a/src/components/GameDetailsModal.tsx
+++ b/src/components/GameDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './styles/GameDetailsModal.css';
 import { IGame } from '../types/game';
 import { Badge, Card, ListGroup, Row, Col, ProgressBar } from 'react-bootstrap';
@@ -11,8 +11,18 @@ interface GameDetailsModalProps {
 const GameDetailsModal: React.FC<GameDetailsModalProps> = ({ game, closeModal }) => {
     const pcRequirements = game.platforms.find(p => p.platform.slug === 'pc')?.requirements_en;
 
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                closeModal();
+            }
+        };
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [closeModal]);
+
     return (
-        <div className="modal-overlay">
+        <div className="modal-overlay" onClick={(e) => e.target === e.currentTarget && closeModal()}>
             <div className="modal-box">
                 <div className="modal-header">
                     <h5 className="modal-title">{game.name}</h5>

--- a/src/components/__tests__/GameDetailsModal.test.tsx
+++ b/src/components/__tests__/GameDetailsModal.test.tsx
@@ -1,0 +1,52 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference types="vitest" />
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import GameDetailsModal from '../GameDetailsModal';
+import { IGame } from '../../types/game';
+
+const mockGame: IGame = {
+  id: 1,
+  slug: 'game-1',
+  name: 'Game 1',
+  released: '2020-01-01',
+  tba: false,
+  background_image: '/assets/svg/no-game-image.svg',
+  rating: 4,
+  rating_top: 5,
+  ratings: [],
+  ratings_count: 0,
+  reviews_text_count: 0,
+  added: 0,
+  added_by_status: { yet: 0, owned: 0, beaten: 0, toplay: 0, dropped: 0, playing: 0 },
+  metacritic: 0,
+  playtime: 0,
+  suggestions_count: 0,
+  updated: '',
+  user_game: null,
+  reviews_count: 0,
+  saturated_color: '',
+  dominant_color: '',
+  platforms: [],
+  parent_platforms: [],
+  genres: [],
+  stores: [],
+};
+
+describe('GameDetailsModal interactions', () => {
+  it('closes when clicking the overlay', async () => {
+    const close = vi.fn();
+    render(<GameDetailsModal game={mockGame} closeModal={close} />);
+    const overlay = document.querySelector('.modal-overlay') as HTMLElement;
+    await userEvent.click(overlay);
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('closes when Escape key is pressed', async () => {
+    const close = vi.fn();
+    render(<GameDetailsModal game={mockGame} closeModal={close} />);
+    await userEvent.keyboard('{Escape}');
+    expect(close).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- close modal on overlay clicks or Escape key press
- add tests for GameDetailsModal interactions

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68428bef2b78832487a7f0c795d58c1f