### PR TITLE
Add aria-label to ThemeToggle input and update tests

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -25,7 +25,12 @@ const ThemeToggle: React.FC = () => {
 
     return (
         <label className="switch">
-            <input type="checkbox" checked={isDark} onChange={toggleTheme} />
+            <input
+                type="checkbox"
+                checked={isDark}
+                onChange={toggleTheme}
+                aria-label="Toggle dark mode"
+            />
             <span className="slider round">
                 <span className="icon-left">
                     <FaSun size={15} />

--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -25,4 +25,10 @@ describe('ThemeToggle', () => {
     expect(document.body.classList.contains('dark-mode')).toBe(false);
     expect(localStorage.getItem('theme')).toBe('light');
   });
+
+  it('includes an aria-label for accessibility', () => {
+    render(<ThemeToggle />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-label', 'Toggle dark mode');
+  });
 });


### PR DESCRIPTION
## Summary
- improve accessibility on the theme toggle by adding an `aria-label`
- test that the theme toggle has this attribute

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68428bf7503c8324a753023f90d0a750