### PR TITLE
Enhance carousel caption overlay

### DIFF
--- a/src/components/TopGamesCarousel.tsx
+++ b/src/components/TopGamesCarousel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { IGame } from '../types/game';
 import { Carousel } from 'bootstrap';
+import './styles/TopGamesCarousel.css';
 
 interface Props {
     topGames: IGame[];
@@ -50,7 +51,7 @@ const TopGamesCarousel: React.FC<Props> = ({ topGames }) => {
                             alt={game.name}
                             style={{ maxHeight: '500px', objectFit: 'cover' }}
                         />
-                        <div className="carousel-caption d-none d-md-block bg-dark bg-opacity-50 rounded px-3 py-2">
+                        <div className="carousel-caption d-none d-md-block top-games-overlay rounded px-3 py-2">
                             <h1>{`#${index + 1}`}</h1>
                             <h5>{game.name}</h5>
                             <p>Rating: {game.rating} | Released: {game.released}</p>

--- a/src/components/__tests__/TopGamesCarousel.test.tsx
+++ b/src/components/__tests__/TopGamesCarousel.test.tsx
@@ -1,0 +1,44 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference types="vitest" />
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import TopGamesCarousel from '../TopGamesCarousel';
+import { IGame } from '../../types/game';
+
+const mockGames: IGame[] = [
+  {
+    id: 1,
+    slug: 'game-1',
+    name: 'Game 1',
+    released: '2020-01-01',
+    tba: false,
+    background_image: '/assets/svg/no-game-image.svg',
+    rating: 4,
+    rating_top: 5,
+    ratings: [],
+    ratings_count: 0,
+    reviews_text_count: 0,
+    added: 0,
+    added_by_status: { yet: 0, owned: 0, beaten: 0, toplay: 0, dropped: 0, playing: 0 },
+    metacritic: 0,
+    playtime: 0,
+    suggestions_count: 0,
+    updated: '',
+    user_game: null,
+    reviews_count: 0,
+    saturated_color: '',
+    dominant_color: '',
+    platforms: [],
+    parent_platforms: [],
+    genres: [],
+    stores: [],
+  },
+];
+
+describe('TopGamesCarousel', () => {
+  it('renders caption overlay with custom class', () => {
+    const { container } = render(<TopGamesCarousel topGames={mockGames} />);
+    const overlay = container.querySelector('.top-games-overlay');
+    expect(overlay).toBeInTheDocument();
+  });
+});

--- a/src/components/styles/TopGamesCarousel.css
+++ b/src/components/styles/TopGamesCarousel.css
@@ -1,0 +1,6 @@
+.top-games-overlay {
+    background-color: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    color: #fff;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}


### PR DESCRIPTION
## Summary
- add custom overlay class to `TopGamesCarousel`
- style the overlay with dark background and blur
- test that overlay class renders

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68428c0c0b248324b171d9b8bbe15cf1