### PR TITLE
Add environment variable example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_RAWG_API_KEY=your_rawg_api_key_here

--- a/README.md
+++ b/README.md
@@ -40,9 +40,15 @@ cd play-peek
 yarn
 ```
 
-### 3. Add `.env` file
+### 3. Configure environment variables
 
-Create a `.env` file in the root:
+Copy `.env.example` to `.env`:
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env` and set your RAWG API key:
 
 ```env
 VITE_RAWG_API_KEY=your_rawg_api_key_here


### PR DESCRIPTION
## Summary
- add `.env.example` with `VITE_RAWG_API_KEY`
- update README to instruct copying the example for environment setup

## Testing
- `yarn install`
- `yarn lint`
- `yarn test --run`


------
https://chatgpt.com/codex/tasks/task_e_6842b71183808324b0704df1422b0d43