### PR TITLE
Fix README tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ yarn dev
 ### 5. Run tests
 
 ```bash
-yarn install
 yarn test
 ```
 


### PR DESCRIPTION
## Summary
- remove redundant `yarn install` step from tests section

## Testing
- `yarn test --run`


------
https://chatgpt.com/codex/tasks/task_e_6842b71008008324907a151f5a573836