### PR TITLE
Fix act warnings in tests

### DIFF
--- a/src/components/__tests__/GameCard.test.tsx
+++ b/src/components/__tests__/GameCard.test.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference types="vitest" />
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
 import GameCard from '../GameCard';
@@ -38,7 +38,10 @@ describe('GameCard', () => {
   it('opens modal when Details button is clicked', async () => {
     render(<GameCard game={mockGame} />);
     const btn = screen.getByRole('button', { name: /details/i });
-    await userEvent.click(btn);
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.click(btn);
+    });
     // Modal should appear
     expect(screen.getByRole('button', { name: /×/i })).toBeInTheDocument();
   });

--- a/src/components/__tests__/ThemeToggle.test.tsx
+++ b/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference types="vitest" />
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ThemeToggle from '../ThemeToggle';
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -14,13 +14,16 @@ describe('ThemeToggle', () => {
   it('toggling checkbox updates body class and localStorage', async () => {
     render(<ThemeToggle />);
     const checkbox = screen.getByRole('checkbox');
+    const user = userEvent.setup();
 
     // initial state should be dark mode
     expect(checkbox).toBeChecked();
     expect(document.body.classList.contains('dark-mode')).toBe(true);
     expect(localStorage.getItem('theme')).toBe('dark');
 
-    await userEvent.click(checkbox);
+    await act(async () => {
+      await user.click(checkbox);
+    });
     expect(checkbox).not.toBeChecked();
     expect(document.body.classList.contains('dark-mode')).toBe(false);
     expect(localStorage.getItem('theme')).toBe('light');


### PR DESCRIPTION
## Summary
- wrap state-changing clicks in GameCard and ThemeToggle tests with `act`

## Testing
- `yarn test --run`

------
https://chatgpt.com/codex/tasks/task_e_6842b70069c083249ad0ecc117072208