### PR TITLE
Silence console errors during search results failure test

### DIFF
--- a/src/pages/__tests__/SearchResults.test.tsx
+++ b/src/pages/__tests__/SearchResults.test.tsx
@@ -33,6 +33,9 @@ describe('SearchResults', () => {
   it('displays error when fetch fails', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (axios.get as unknown as any).mockRejectedValue(new Error('fail'));
+    const consoleErrorMock = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
 
     render(
       <MemoryRouter initialEntries={["/search?q=test"]}>
@@ -42,5 +45,6 @@ describe('SearchResults', () => {
 
     const alert = await screen.findByText(/failed to fetch search results/i);
     expect(alert).toBeInTheDocument();
+    consoleErrorMock.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- mock `console.error` in `SearchResults.test.tsx` to avoid noisy stderr output

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6842bcdcbe588324b6939732a33103f9