### PR TITLE
Add eslint ignore file for Yarn PnP

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+.pnp.cjs
+.pnp.loader.mjs
+


### PR DESCRIPTION
## Summary
- add `.eslintignore` file to exclude `.pnp.cjs` and `.pnp.loader.mjs`

## Testing
- `yarn lint` *(fails: `.eslintignore` deprecated)*
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6846b7cf53f483248e5decaabffbd3c3