### PR TITLE
Add response error checks

### DIFF
--- a/src/services/__tests__/api.test.ts
+++ b/src/services/__tests__/api.test.ts
@@ -17,7 +17,14 @@ const loadApi = async () => {
 };
 
 beforeEach(() => {
-  fetchMock = vi.fn().mockResolvedValue({ json: vi.fn().mockResolvedValue(sampleResponse) });
+  fetchMock = vi
+    .fn()
+    .mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: vi.fn().mockResolvedValue(sampleResponse),
+    });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (global as any).fetch = fetchMock;
 });
@@ -81,5 +88,16 @@ describe('api services', () => {
     fetchMock.mockRejectedValue(new Error('fail'));
     const { fetchGames } = await loadApi();
     await expect(fetchGames()).rejects.toThrow('fail');
+  });
+
+  it('throws when response not ok', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      json: vi.fn(),
+    });
+    const { fetchGames } = await loadApi();
+    await expect(fetchGames()).rejects.toThrow('Error 500: Server Error');
   });
 });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -7,6 +7,9 @@ const BASE_URL = 'https://api.rawg.io/api';
 
 export const fetchGames = async () => {
   const res = await fetch(`${BASE_URL}/games?key=${API_KEY}`);
+  if (!res.ok) {
+    throw new Error(`Error ${res.status}: ${res.statusText}`);
+  }
   const data = await res.json();
   return data.results;
 };
@@ -15,36 +18,54 @@ export const fetchUpcomingGames = async (): Promise<IGame[]> => {
   const today = new Date().toISOString().split('T')[0];
   const nextYearEnd = new Date(new Date().getFullYear() + 1, 11, 31).toISOString().split('T')[0];
   const res = await fetch(`${BASE_URL}/games?dates=${today},${nextYearEnd}&ordering=-added&page_size=20&key=${API_KEY}`);
+  if (!res.ok) {
+    throw new Error(`Error ${res.status}: ${res.statusText}`);
+  }
   const data = await res.json();
   return data.results;
 };
 
 export const fetchGenres = async (): Promise<IGenre[]> => {
   const res = await fetch(`${BASE_URL}/genres?key=${API_KEY}`);
+  if (!res.ok) {
+    throw new Error(`Error ${res.status}: ${res.statusText}`);
+  }
   const data = await res.json();
   return data.results;
 };
 
 export const fetchGamesByGenre = async (genreId: number): Promise<IGame[]> => {
   const res = await fetch(`${BASE_URL}/games?genres=${genreId}&key=${API_KEY}`);
+  if (!res.ok) {
+    throw new Error(`Error ${res.status}: ${res.statusText}`);
+  }
   const data = await res.json();
   return data.results;
 };
 
 export const fetchPlatforms = async (): Promise<IPlatform[]> => {
   const res = await fetch(`${BASE_URL}/platforms?key=${API_KEY}`);
+  if (!res.ok) {
+    throw new Error(`Error ${res.status}: ${res.statusText}`);
+  }
   const data = await res.json();
   return data.results;
 };
 
 export const fetchGamesByPlatform = async (platformId: number): Promise<IGame[]> => {
   const res = await fetch(`${BASE_URL}/games?platforms=${platformId}&key=${API_KEY}`);
+  if (!res.ok) {
+    throw new Error(`Error ${res.status}: ${res.statusText}`);
+  }
   const data = await res.json();
   return data.results;
 };
 
 export const fetchTopRatedGames = async (): Promise<IGame[]> => {
   const res = await fetch(`${BASE_URL}/games?ordering=-rating&page_size=20&key=${API_KEY}`);
+  if (!res.ok) {
+    throw new Error(`Error ${res.status}: ${res.statusText}`);
+  }
   const data = await res.json();
   return data.results;
 };


### PR DESCRIPTION
## Summary
- ensure all game API services throw when responses are not ok
- update API service tests to verify new error handling

## Testing
- `yarn install`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6846b7d2271c8324912c0c5feb6b7494